### PR TITLE
Changed HTML5 data attribute name

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ image_tag "logo.png"
 image_tag_with_at2x "logo.png"
 ```
 
-This will output the HTML similar to::
+This will output the HTML similar to:
 ```html
-<img data-at2x="/assets/logo@2x.png" src="/assets/logo.png">
+<img data-rjs="/assets/logo@2x.png" src="/assets/logo.png">
 ```
 
 ### SCSS mixin

--- a/lib/retinajs-rails.rb
+++ b/lib/retinajs-rails.rb
@@ -6,7 +6,7 @@ end
 module ImageHelper
   def image_tag_with_at2x(name_at_1x, options={})
     name_at_2x = name_at_1x.gsub(%r{\.\w+$}, '@2x\0')
-    image_tag(name_at_1x, options.merge("data-at2x" => asset_path(name_at_2x)))
+    image_tag(name_at_1x, options.merge("data-rjs" => asset_path(name_at_2x)))
   end
 end
 ActionView::Base.send :include, ImageHelper


### PR DESCRIPTION
According to the [current README](https://github.com/imulus/retinajs/blob/master/README.md#manually-specifying-a-high-res-url) the `data-at2x` attribute is dead and needs to be replaced with their `data-rjs` attribute for specifying image paths manually. 

This gem currently doesn't work for me for `<img>` tags, I'm not sure if it does for anyone else although retinajs itself has [major issues](https://github.com/imulus/retinajs/issues/253).

I've tested this by adding the helper to my ApplicationController with the changed attribute and it works for me.